### PR TITLE
fix(manipulation): initial arm state

### DIFF
--- a/tiago_sim/launch/tiago_sim.launch.py
+++ b/tiago_sim/launch/tiago_sim.launch.py
@@ -1,13 +1,13 @@
 # Copyright (c) 2024 PAL Robotics S.L. All rights reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the License is distributed on an 'AS IS' BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
@@ -15,8 +15,6 @@
 from dataclasses import dataclass
 import os
 from os import environ, pathsep
-from launch_ros.actions import Node
-from launch.actions import TimerAction
 
 from ament_index_python.packages import get_package_prefix
 from launch import LaunchDescription
@@ -24,6 +22,7 @@ from launch.actions import (
     DeclareLaunchArgument,
     SetEnvironmentVariable,
     SetLaunchConfiguration,
+    TimerAction,
 )
 from launch.conditions import IfCondition
 from launch.substitutions import LaunchConfiguration
@@ -31,6 +30,7 @@ from launch_pal.actions import CheckPublicSim
 from launch_pal.arg_utils import LaunchArgumentsBase
 from launch_pal.include_utils import include_scoped_launch_py_description
 from launch_pal.robot_arguments import CommonArgs
+from launch_ros.actions import Node
 from tiago_description.launch_arguments import TiagoArgs
 
 
@@ -68,103 +68,104 @@ def declare_actions(
     launch_description: LaunchDescription, launch_args: LaunchArguments
 ):
     # Set use_sim_time to True
-    set_sim_time = SetLaunchConfiguration("use_sim_time", "True")
+    set_sim_time = SetLaunchConfiguration('use_sim_time', 'True')
     launch_description.add_action(set_sim_time)
 
-    # Shows error if is_public_sim is not set to True when using public simulation
+    # Shows error if is_public_sim is not set to True when using public
+    # simulation
     public_sim_check = CheckPublicSim()
     launch_description.add_action(public_sim_check)
 
-    robot_name = "tiago"
+    robot_name = 'tiago'
     packages = [
-        "tiago_description",
-        "pmb2_description",
-        "pal_hey5_description",
-        "pal_gripper_description",
-        "pal_robotiq_description",
-        "omni_base_description",
-        "tiago_sim",
+        'tiago_description',
+        'pmb2_description',
+        'pal_hey5_description',
+        'pal_gripper_description',
+        'pal_robotiq_description',
+        'omni_base_description',
+        'tiago_sim',
     ]
 
     model_path = get_model_paths(packages)
 
-    gz_model_path_env_var = SetEnvironmentVariable("GZ_SIM_RESOURCE_PATH", model_path)
+    gz_model_path_env_var = SetEnvironmentVariable('GZ_SIM_RESOURCE_PATH', model_path)
     launch_description.add_action(gz_model_path_env_var)
 
     gazebo = include_scoped_launch_py_description(
-        pkg_name="tiago_sim",
-        paths=["launch", "br2_gazebo.launch.py"],
+        pkg_name='tiago_sim',
+        paths=['launch', 'br2_gazebo.launch.py'],
         env_vars=[gz_model_path_env_var],
         launch_arguments={
-            "world_name": launch_args.world_name,
-            "model_paths": packages,
-            "resource_paths": packages,
+            'world_name': launch_args.world_name,
+            'model_paths': packages,
+            'resource_paths': packages,
         },
     )
     launch_description.add_action(gazebo)
 
     navigation = include_scoped_launch_py_description(
-        pkg_name="tiago_2dnav",
-        paths=["launch", "tiago_nav_bringup.launch.py"],
+        pkg_name='tiago_2dnav',
+        paths=['launch', 'tiago_nav_bringup.launch.py'],
         launch_arguments={
-            "robot_name": robot_name,
-            "is_public_sim": launch_args.is_public_sim,
-            "laser": launch_args.laser_model,
-            "base_type": launch_args.base_type,
-            "world_name": launch_args.world_name,
-            "slam": launch_args.slam,
-            "use_sim_time": LaunchConfiguration("use_sim_time"),
+            'robot_name': robot_name,
+            'is_public_sim': launch_args.is_public_sim,
+            'laser': launch_args.laser_model,
+            'base_type': launch_args.base_type,
+            'world_name': launch_args.world_name,
+            'slam': launch_args.slam,
+            'use_sim_time': LaunchConfiguration('use_sim_time'),
         },
-        condition=IfCondition(LaunchConfiguration("navigation")),
+        condition=IfCondition(LaunchConfiguration('navigation')),
     )
     launch_description.add_action(navigation)
 
     advanced_navigation = include_scoped_launch_py_description(
-        pkg_name="tiago_advanced_2dnav",
-        paths=["launch", "tiago_advanced_nav_bringup.launch.py"],
-        launch_arguments={"base_type": launch_args.base_type},
-        condition=IfCondition(LaunchConfiguration("advanced_navigation")),
+        pkg_name='tiago_advanced_2dnav',
+        paths=['launch', 'tiago_advanced_nav_bringup.launch.py'],
+        launch_arguments={'base_type': launch_args.base_type},
+        condition=IfCondition(LaunchConfiguration('advanced_navigation')),
     )
     launch_description.add_action(advanced_navigation)
 
     move_group = include_scoped_launch_py_description(
-        pkg_name="tiago_moveit_config",
-        paths=["launch", "move_group.launch.py"],
+        pkg_name='tiago_moveit_config',
+        paths=['launch', 'move_group.launch.py'],
         launch_arguments={
-            "robot_name": robot_name,
-            "use_sim_time": LaunchConfiguration("use_sim_time"),
-            "namespace": launch_args.namespace,
-            "base_type": launch_args.base_type,
-            "arm_type": launch_args.arm_type,
-            "end_effector": launch_args.end_effector,
-            "ft_sensor": launch_args.ft_sensor,
+            'robot_name': robot_name,
+            'use_sim_time': LaunchConfiguration('use_sim_time'),
+            'namespace': launch_args.namespace,
+            'base_type': launch_args.base_type,
+            'arm_type': launch_args.arm_type,
+            'end_effector': launch_args.end_effector,
+            'ft_sensor': launch_args.ft_sensor,
         },
-        condition=IfCondition(LaunchConfiguration("moveit")),
+        condition=IfCondition(LaunchConfiguration('moveit')),
     )
     launch_description.add_action(move_group)
 
     robot_spawn = include_scoped_launch_py_description(
-        pkg_name="tiago_gazebo",
+        pkg_name='tiago_gazebo',
         env_vars=[gz_model_path_env_var],
-        paths=["launch", "robot_spawn.launch.py"],
-        launch_arguments={"robot_name": robot_name, "base_type": launch_args.base_type},
+        paths=['launch', 'robot_spawn.launch.py'],
+        launch_arguments={'robot_name': robot_name, 'base_type': launch_args.base_type},
     )
     launch_description.add_action(robot_spawn)
 
     tiago_bringup = include_scoped_launch_py_description(
-        pkg_name="tiago_bringup",
-        paths=["launch", "tiago_bringup.launch.py"],
+        pkg_name='tiago_bringup',
+        paths=['launch', 'tiago_bringup.launch.py'],
         launch_arguments={
-            "use_sim_time": LaunchConfiguration("use_sim_time"),
-            "arm_type": launch_args.arm_type,
-            "laser_model": launch_args.laser_model,
-            "camera_model": launch_args.camera_model,
-            "base_type": launch_args.base_type,
-            "wrist_model": launch_args.wrist_model,
-            "ft_sensor": launch_args.ft_sensor,
-            "end_effector": launch_args.end_effector,
-            "has_screen": launch_args.has_screen,
-            "is_public_sim": launch_args.is_public_sim,
+            'use_sim_time': LaunchConfiguration('use_sim_time'),
+            'arm_type': launch_args.arm_type,
+            'laser_model': launch_args.laser_model,
+            'camera_model': launch_args.camera_model,
+            'base_type': launch_args.base_type,
+            'wrist_model': launch_args.wrist_model,
+            'ft_sensor': launch_args.ft_sensor,
+            'end_effector': launch_args.end_effector,
+            'has_screen': launch_args.has_screen,
+            'is_public_sim': launch_args.is_public_sim,
         },
     )
     launch_description.add_action(tiago_bringup)
@@ -174,11 +175,11 @@ def declare_actions(
         period=15.0,
         actions=[
             Node(
-                package="tiago_gazebo",
-                executable="tuck_arm.py",
-                name="tuck_arm",
-                output="screen",
-                parameters=[{"use_sim_time": True}],
+                package='tiago_gazebo',
+                executable='tuck_arm.py',
+                name='tuck_arm',
+                output='screen',
+                parameters=[{'use_sim_time': True}],
             )
         ],
     )
@@ -186,16 +187,16 @@ def declare_actions(
 
 
 def get_model_paths(packages_names):
-    model_paths = ""
+    model_paths = ''
     for package_name in packages_names:
-        if model_paths != "":
+        if model_paths != '':
             model_paths += pathsep
 
         package_path = get_package_prefix(package_name)
-        model_path = os.path.join(package_path, "share")
+        model_path = os.path.join(package_path, 'share')
         model_paths += model_path
 
-    if "GZ_SIM_RESOURCE_PATH" in environ:
-        model_paths += pathsep + environ["GZ_SIM_RESOURCE_PATH"]
+    if 'GZ_SIM_RESOURCE_PATH' in environ:
+        model_paths += pathsep + environ['GZ_SIM_RESOURCE_PATH']
 
     return model_paths


### PR DESCRIPTION
## 📝 Issue Summary

**Problem**
When launching TIAGo in simulation, the robot spawns in a **self-collision state** (torso + arm\_1).
This makes **MoveIt** reject all plans from the initial state since it is considered invalid, even though the controllers and execution are working fine.

**Solution**
Without modifying TIAGo’s URDF/Xacro (third-party package), I leveraged the existing **`tuck_arm.py`** script.
It is now launched in `tiago_sim.launch.py` with a short delay, ensuring the robot automatically moves into a valid pose after all controllers are running.

**Result**
The robot always starts in a **valid, collision-free configuration**, allowing MoveIt to plan and execute motions normally.

**✅ Demo screenshot after fix**
<img width="1920" height="1080" alt="Screenshot from 2025-09-22 00-46-14" src="https://github.com/user-attachments/assets/87beff90-a4c9-497f-a464-6422b67ce463" />
<img width="1920" height="1080" alt="Screenshot from 2025-09-22 00-47-47" src="https://github.com/user-attachments/assets/4f0a8888-e3a4-4800-bd0e-99249bcba01e" />


