### PR TITLE
Fix Ubuntu 24.04 pip install by adding `--break-system-packages`

### DIFF
--- a/setup_third_party_pkgs.sh
+++ b/setup_third_party_pkgs.sh
@@ -17,4 +17,4 @@ rosdep update --rosdistro=$ROS_DISTRO
 rosdep install --from-paths . --ignore-src -r -y --rosdistro=$ROS_DISTRO
 
 # Install Python requirements for YOLO
-pip3 install -r ThirdParty/yolo_ros/requirements.txt
+pip3 install -r ThirdParty/yolo_ros/requirements.txt --break-system-packages


### PR DESCRIPTION
**PR Description:**
This PR updates the dependency installation script for `ThirdParty/yolo_ros` to work on Ubuntu 24.04.

### Background

Ubuntu 24.04 enforces PEP 668 (“externally managed environment”), which makes this command fail during setup:

```bash
pip3 install -r ThirdParty/yolo_ros/requirements.txt
```

### Change

Add `--break-system-packages` to the `pip3 install` invocation in the install script:

```diff
- pip3 install -r ThirdParty/yolo_ros/requirements.txt
+ pip3 install -r ThirdParty/yolo_ros/requirements.txt --break-system-packages 
```

### Result

* Setup succeeds on Ubuntu 24.04 out of the box.
* No impact on existing Ubuntu 22.04 / 20.04 flows.
* Keeps current system-install behavior consistent, just unblocked for new OS versions.
